### PR TITLE
Settings in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,30 @@ Output:
 | `-p`, `--prefix` | `'test'` | A string that comes before all tests. |
 | `-s`, `--separator` | `':'` | Character that separates the prefix from the test name. |
 
-
 You can use these options like this:
 
 ```bash
-$ tst --separator -
+$ tst --prefix unit-test --separator -
 ```
 
-This will suggest any scripts that look like `test-TESTNAME`.
+This will suggest any scripts that look like `unit-test-TESTNAME`.
+
+### Configuration in your `package.json` file
+
+You may also add a `"tst"` object to your project's `package.json` file.
+
+```json
+{
+  "scripts": {
+    "test": "test for things",
+    "unit-test-api": "test just the api",
+  },
+  "tst": {
+    "prefix": "unit-test",
+    "separator": "-"
+  }
+}
+```
 
 ## Writing your tests
 
@@ -74,3 +90,4 @@ I'd love your contributions! Feel free to open up an issue or submit a PR. Thank
 ## Changelog
 
 - 1.0.0 - Initial release
+- 1.0.1 - Enable settings in `package.json`

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const program = require('commander');
 const path = require('path');
 const tstPkg = require('./package.json');
-const getTestScripts = require('./lib/get-test-scripts');
+const getPackage = require('./lib/get-package');
 const runCommand = require('./lib/run-command');
 const askForScripts = require('./lib/ask-for-scripts');
 const formatTestScripts = require('./lib/format-test-scripts');
@@ -21,21 +21,21 @@ program
   .action((test) => testArg = test)
   .parse(process.argv);
 
-const scripts = getTestScripts();
-if (typeof scripts === 'string') {
-  console.log(`\n${scripts}\n`);
+const pkg = getPackage();
+if (typeof pkg === 'string') {
+  console.log(`\n${pkg}\n`);
   return;
 }
 
-const prefix = program.prefix || 'test';
-const separator = program.separator || ':';
+const prefix = program.prefix || (pkg.tst && pkg.tst.prefix ? pkg.tst.prefix : 'test');
+const separator = program.separator || (pkg.tst && pkg.tst.separator ? pkg.tst.separator : ':');
 const preString = prefix + separator;
 
 if (testArg) {
   const script = testArg.startsWith(preString) ? testArg : preString + testArg;
   return runCommand(script);
 } else {
-  const testScripts = formatTestScripts(scripts, prefix, separator);  
+  const testScripts = formatTestScripts(pkg.scripts, prefix, separator);  
   askForScripts(testScripts)
     .then((answers) => {
       const script = answers.testScript === '*' ? 'test' : preString + answers.testScript;

--- a/lib/get-package.js
+++ b/lib/get-package.js
@@ -21,5 +21,5 @@ module.exports = (cwd = process.cwd()) => {
     return chalk.red('[tst] Your package.json does not have a test script!');
   }
 
-  return pkg.scripts;
+  return pkg;
 }

--- a/lib/run-command.js
+++ b/lib/run-command.js
@@ -1,6 +1,6 @@
 const execa = require('execa');
 const chalk = require('chalk');
-const getTestScripts = require('./get-test-scripts');
+const getPackage = require('./get-package');
 
 /**
  * Runs the given command using execa, or console logs
@@ -9,7 +9,7 @@ const getTestScripts = require('./get-test-scripts');
  * @returns {Promise<never>}
  */
 module.exports = (cmd) => {
-  const scripts = getTestScripts();
+  const {scripts} = getPackage();
   const hasScript = key => Object.keys(scripts).some(x => Boolean(scripts[key]));
   
   if (!hasScript(cmd)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "test-selector",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-selector",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Prompts the user to run specific test suites in a project.",
   "main": "index.js",
   "bin": {

--- a/test/fixtures/with-settings/package.json
+++ b/test/fixtures/with-settings/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "test one",
+    "test:two": "test two",
+    "test-three": "test three",
+    "pizza-four": "test four"
+  },
+  "tst": {
+    "prefix": "pizza",
+    "separator": "-"
+  }
+}

--- a/test/get-package.js
+++ b/test/get-package.js
@@ -1,27 +1,27 @@
-const getTestScripts = require('../lib/get-test-scripts');
+const getPackage = require('../lib/get-package');
 const expect = require('chai').expect;
 const path = require('path');
 const chalk = require('chalk');
 
-describe('get test scripts', () => {
+describe('get package', () => {
   it('returns the correct test scripts', () => {
-    const scripts = getTestScripts(path.join(__dirname, 'fixtures'));
+    const {scripts} = getPackage(path.join(__dirname, 'fixtures'));
     const pkg = require('./fixtures/package.json');
     expect(scripts).to.deep.equal(pkg.scripts);
   });
 
   it('returns an error when the package.json has no test scripts', () => {
-    const scripts = getTestScripts(path.join(__dirname, 'fixtures', 'no-tests'));
-    expect(scripts).to.equal(chalk.red('[tst] Your package.json does not have a test script!'));
+    const pkg = getPackage(path.join(__dirname, 'fixtures', 'no-tests'));
+    expect(pkg).to.equal(chalk.red('[tst] Your package.json does not have a test script!'));
   });
 
   it('returns an error when the package.json does not exist', () => {
-    const scripts = getTestScripts(path.join(__dirname, 'fixtures', 'no-package'));
-    expect(scripts).to.equal(chalk.red('[tst] There is no package.json in your current directory.'));
+    const pkg = getPackage(path.join(__dirname, 'fixtures', 'no-package'));
+    expect(pkg).to.equal(chalk.red('[tst] There is no package.json in your current directory.'));
   });
 
   it('returns this project\'s scripts with no cwd argument', () => {
-    const scripts = getTestScripts();
+    const {scripts} = getPackage();
     const tstPkgScripts = require('../package.json').scripts;
     expect(scripts).to.deep.equal(tstPkgScripts);    
   });


### PR DESCRIPTION
@matchai had a good suggestion to enable settings in a project's `package.json` file. The settings look like:

```json
{
  "name": "example-project",
  "tst": {
    "prefix": "unit-test",
    "separator": "-"
  }
}
```

- [x] Check for `package.json` settings
- [x] Add/adjust tests
- [x] Document change in README 